### PR TITLE
#10 Getting test in place for generating the output_uri_replace string. ...

### DIFF
--- a/src/main/groovy/com/marklogic/gradle/task/client/LoadAssetsViaMlcpTask.groovy
+++ b/src/main/groovy/com/marklogic/gradle/task/client/LoadAssetsViaMlcpTask.groovy
@@ -2,7 +2,7 @@ package com.marklogic.gradle.task.client
 
 import org.gradle.api.tasks.TaskAction
 
-import com.marklogic.appdeployer.AppConfig;
+import com.marklogic.appdeployer.AppConfig
 import com.marklogic.client.DatabaseClientFactory
 import com.marklogic.client.DatabaseClientFactory.Authentication
 import com.marklogic.clientutil.modulesloader.impl.DefaultModulesLoader
@@ -16,8 +16,20 @@ import com.marklogic.gradle.task.MlcpTask
  * This prevents LoadModulesTask from loading each asset module again.
  */
 class LoadAssetsViaMlcpTask extends MlcpTask {
-
+    
+    /**
+     * The directory that contains all assets modules consolidated from the application and any of its libraries. Consolidating
+     * everything into one directory means we can easily load it via a single mlcp import call.
+     */
     String consolidatedAssetsPath = "build/ml-gradle/consolidatedAssets"
+    
+    /**
+     * The subdirectory in the consolidated assets directory that contains the modules to be loaded. This can be blank.
+     * It defaults to /ext under the assumption that a developer wants all of an application's asset modules to be 
+     * accessible via the REST API, even though they're being loaded via mlcp. 
+     */
+    String inputFilePathPrefix = "/ext"
+    
     Authentication auth = Authentication.DIGEST
 
     @TaskAction
@@ -43,10 +55,15 @@ class LoadAssetsViaMlcpTask extends MlcpTask {
     protected void setMlcpParameters(AppConfig config) {
         setCommand("IMPORT")
         setPort(config.getModulesXdbcPort())
-        setInput_file_path(consolidatedAssetsPath + "/ext")
+        setInput_file_path(consolidatedAssetsPath + inputFilePathPrefix)
 
-        // This pattern removes everything before the /ext folder; TODO need some unit tests for this! Should move
-        // to a Java class and test it there.
-        setOutput_uri_replace("\"" + new File(consolidatedAssetsPath).getAbsolutePath().replace("\\", "/").replaceFirst("([a-zA-Z]:)", {"/"+it[0].toUpperCase()}) + ", ''\"")
+        setOutput_uri_replace(LoadAssetsViaMlcpTask.generateOutputUriReplace(consolidatedAssetsPath))
+    }
+
+    /**
+     * This pattern removes everything ending with the consolidated assets directory.
+     */
+    public static String generateOutputUriReplace(String consolidatedAssetsPath) {
+        return "\"" + new File(consolidatedAssetsPath).getAbsolutePath().replace("\\", "/").replaceFirst("([a-zA-Z]:)", {"/"+it[0].toUpperCase()}) + ", ''\""
     }
 }

--- a/src/test/groovy/com/marklogic/gradle/task/client/LoadAssetsViaMlcpTaskTest.java
+++ b/src/test/groovy/com/marklogic/gradle/task/client/LoadAssetsViaMlcpTaskTest.java
@@ -1,0 +1,20 @@
+package com.marklogic.gradle.task.client;
+
+import org.junit.Assert;
+import org.junit.Test;
+
+public class LoadAssetsViaMlcpTaskTest extends Assert {
+
+    @Test
+    public void generateOutputUriReplace() {
+        String assetsPath = "build\\ml-gradle\\consolidatedAssets";
+
+        String output = LoadAssetsViaMlcpTask.generateOutputUriReplace(assetsPath);
+        // System.out.println(output);
+        assertTrue("The replace string must start and end with double quotes",
+                output.startsWith("\"") && output.endsWith("\""));
+        assertTrue(
+                "The replace string must have Windows-style back slashes replaced with forward slashes, and the full replace string should be replaced with empty single quotes",
+                output.endsWith("/build/ml-gradle/consolidatedAssets, ''\""));
+    }
+}


### PR DESCRIPTION
...Also made the input file path prefix configurable.

The point of this is to allow this task to work on a Roxy-style project where asset modules are not in a directory named "ext". Many Roxy projects store modules under "/src" and don't have an "ext" root folder as dictated by the REST API, so this task needs to allow that. That should be possible by making inputFilePathPrefix configurable - it defaults to "/ext", but it can be set to "" instead when the modules aren't all in an "ext" folder. 