### PR TITLE
#65 Don't let mlWatch blow up when there's an error in a module

### DIFF
--- a/src/main/groovy/com/marklogic/gradle/task/client/WatchTask.groovy
+++ b/src/main/groovy/com/marklogic/gradle/task/client/WatchTask.groovy
@@ -6,6 +6,7 @@ import com.marklogic.appdeployer.command.modules.LoadModulesCommand
 import com.marklogic.client.DatabaseClient
 import com.marklogic.client.modulesloader.ModulesLoader
 import com.marklogic.client.modulesloader.impl.DefaultModulesFinder
+import com.marklogic.client.modulesloader.impl.DefaultModulesLoader
 import com.marklogic.gradle.task.MarkLogicTask
 
 /**
@@ -22,8 +23,12 @@ class WatchTask extends MarkLogicTask {
     @TaskAction
     public void watchModules() {
         LoadModulesCommand command = getProject().property("mlLoadModulesCommand")
+        
         ModulesLoader loader = command.getModulesLoader()
-
+        if (loader instanceof DefaultModulesLoader) {
+            ((DefaultModulesLoader)loader).setCatchExceptions(true)
+        }
+        
         List<String> paths = getAppConfig().getModulePaths()
         println "Watching modules in paths: " + paths
 


### PR DESCRIPTION
Turned out ml-javaclient-util already had support for this, just needed to make use of it in WatchTask. 