### PR TITLE
resolves #69

### DIFF
--- a/examples/corb2-project/build.gradle
+++ b/examples/corb2-project/build.gradle
@@ -1,0 +1,111 @@
+/*
+ * This buildscript shows how corb dependencies can be easily declared and then uses in a Gradle configuration named
+ * "corb". This configuration is then used as the classpath for CorbTask, which is an extension of Gradle's
+ * JavaExec task that exposes the corb options as task attributes. The CorbTask will apply any corb options set via
+ * task attributes, project properties, or System properties.
+ */
+plugins {
+    id "com.marklogic.ml-gradle" version "2.0"
+}
+
+repositories {
+    jcenter()
+
+    // Needed for corb dependencies: XCC, Jasypt(optional)
+    maven { url "http://developer.marklogic.com/maven2/" }
+
+    // Needed to resolve CoRB2
+    maven { url "http://rjrudin.github.io/marklogic-java/releases" }
+}
+
+configurations {
+    // This configuration captures the dependencies for running corb (Content Reprocessing in Bulk).
+    // This is only needed if you want to run corb via Gradle tasks.
+    // If you do, using com.marklogic.gradle.task.CorbTask is a useful starting point, as shown below.
+    corb
+}
+
+dependencies {
+    // required to run CoRB2
+    corb 'com.marklogic:marklogic-corb:2.2.1'
+
+    // optional
+    //corb 'org.jasypt:jasypt:1.9.2' // would be necessary to leverage JasyptDecrypter
+}
+
+/*
+ * ml-gradle adds an instance of com.marklogic.appdeployer.AppConfig to the Gradle project under the key "mlAppConfig".
+ * This instance can be modified to affect the behavior of ml-gradle.
+ */
+ext {
+    // mlAppConfig is an instance of com.marklogic.appdeployer.AppConfig
+    mlAppConfig {
+        // XCC URL for running corb task below and for creating triggers on pre-8.0-4 builds of MarkLogic
+        contentXccUrl = "xcc://${mlUsername}:${mlPassword}@${mlHost}:${mlRestPort}"
+    }
+}
+
+/*
+ * This is an example of both a custom Gradle task and an easy way of invoking Corb.
+ *
+ * Since a custom configuration named "corb" is defined above, the classpath is automatically set.
+ *
+ * Any of the CoRB2 options can be set for the task several ways:
+ * 1.) Properties of the task with a lowerCamelCased naming convention
+ *     (i.e. the CoRB2 option THREAD-COUNT is threadCount)
+ * 2.) Project properties with the naming convention of a "corb" prefix and the UpperCamelCased
+ *     option name (i.e. the CoRB2 option THREAD-COUNT is corbThreadCount and can
+ *     be specified on the commandline as -PcorbThreadCount=12)
+ * 3.) System properties with the CoRB2 option name. (i.e. THREAD-COUNT can be set on the commandline as
+ *       -DTHREAD-COUNT=16)
+ *
+ * A complete list of CoRB2 options can be found at: https://github.com/marklogic/corb2#options
+ *
+ * Examples of how to invoke corb and set options:
+ * 1.) specify options from a properties file using the CoRB2 OPTIONS-FILE option
+ *     gradle corb -PcorbOptionsFile=src/main/ml-modules/ext/corb2-project/corb/options.properties
+ * 2.) Set corb project properties on the commandline
+ *     gradle corb -PcorbUrisModule="src/main/ml-modules/ext/corb2-project/uris.xqy|ADHOC" -PcorbProcessModule="src/main/ml-modules/ext/corb2-project/corb/transform.xqy|ADHOC"
+ * 3.) Set CoRB2 options as System properties on the commandline
+ *     gradle corb -DURIS-MODULE="src/main/ml-modules/ext/corb2-project/uris.xqy|ADHOC" -DPROCESS-MODULE="src/main/ml-modules/ext/corb2-project/corb/transform.xqy|ADHOC"
+ */
+task corb(type: com.marklogic.gradle.task.CorbTask) {
+    /* Either uncomment and set the xccConnectionUri below and set an appropriate XCC connection string,
+     * or specify on the commandline as a project property: -PcorbXccConnectionUri=xcc://user:pass@host:port/content-database
+     * or specify as a System property: -DXCC-CONNECTION-URI=xcc://user:pass@host:port/content-database
+     * or instread of setting the XCC-CONNECTION-URI, set the individual XCC options
+     * (XCC-HOSTNAME, XCC-PORT, XCC-USERNAME, XCC-PASSWORD, XCC-DBNAME)
+     */
+    xccConnectionUri = contentXccUrl
+}
+
+/*
+ * An example corb task that executes the URIS-MODULE and PROCESS-MODULE files
+ * as ADHOC, running from the filesystem, without deploying to the modules database.
+ * This task does not depend on "mlLoadModules" to ensure that the Corb uris/transform modules are loaded.
+ * If you run gradle corbDeployed' gradle corbAdhoc
+ *
+ * Note that the sample uris.xqy and transform.xqy modules just print a log statement for each document in your
+ * content database, so unless there are documents, you won't see any result from this. You of course can modify
+ * the transform.xqy module to perform any action that you would like - this is just to show how to invoke corb from Gradle.
+ */
+task corbAdhoc(type: com.marklogic.gradle.task.CorbTask) {
+    xccConnectionUri = contentXccUrl
+    urisModule = "src/main/ml-modules/ext/corb2-project/corb/uris.xqy|ADHOC"
+    processModule = "src/main/ml-modules/ext/corb2-project/corb/transform.xqy|ADHOC"
+}
+
+/*
+ * An example of a task that depends on mlLoadModules, which will deploy the XQuery modules to the modules database,
+ * and then execute the modules from the modules database.
+ *
+ * Note that the sample uris.xqy and transform.xqy modules just print a log statement for each document in your
+ * content database, so unless there are documents, you won't see any result from this. You of course can modify
+ * the transform.xqy module to perform any action that you would like - this is just to show how to invoke corb from Gradle.
+ */
+task corbDeployed(type: com.marklogic.gradle.task.CorbTask, dependsOn: ['mlLoadModules']) {
+    xccConnectionUri = contentXccUrl
+    moduleRoot = "/ext/corb2-project/corb/"
+    urisModule = "uris.xqy"
+    processModule = "transform.xqy"
+}

--- a/examples/corb2-project/build/ml-last-configured-timestamps.properties
+++ b/examples/corb2-project/build/ml-last-configured-timestamps.properties
@@ -1,0 +1,4 @@
+#
+#Wed Feb 17 11:50:57 EST 2016
+/users/mhansen/code/ml-gradle/examples/corb2-project/src/main/ml-modules/ext/corb2-project/corb/uris.xqy=1455727857380
+/users/mhansen/code/ml-gradle/examples/corb2-project/src/main/ml-modules/ext/corb2-project/corb/transform.xqy=1455727857375

--- a/examples/corb2-project/gradle.properties
+++ b/examples/corb2-project/gradle.properties
@@ -1,0 +1,5 @@
+mlHost=localhost
+mlAppName=corb2-project
+mlRestPort=8140
+mlUsername=admin
+mlPassword=admin

--- a/examples/corb2-project/src/main/ml-modules/ext/corb2-project/corb/options.properties
+++ b/examples/corb2-project/src/main/ml-modules/ext/corb2-project/corb/options.properties
@@ -1,0 +1,3 @@
+URIS-MODULE=src/main/ml-modules/ext/corb2-project/corb/uris.xqy|ADHOC
+PROCESS-MODULE=src/main/ml-modules/ext/corb2-project/corb/transform.xqy|ADHOC
+THREAD-COUNT=12

--- a/examples/corb2-project/src/main/ml-modules/ext/corb2-project/corb/transform.xqy
+++ b/examples/corb2-project/src/main/ml-modules/ext/corb2-project/corb/transform.xqy
@@ -1,0 +1,5 @@
+xquery version "1.0-ml";
+
+declare variable $URI external;
+
+xdmp:log("Calling Corb transform on URI: " || $URI)

--- a/examples/corb2-project/src/main/ml-modules/ext/corb2-project/corb/uris.xqy
+++ b/examples/corb2-project/src/main/ml-modules/ext/corb2-project/corb/uris.xqy
@@ -1,0 +1,9 @@
+xquery version "1.0-ml";
+
+(:
+Sample query that returns all URIs.
+:)
+
+let $uris := cts:uris((), (), cts:and-query(()))
+
+return (count($uris), $uris)

--- a/src/main/groovy/com/marklogic/gradle/task/CorbTask.groovy
+++ b/src/main/groovy/com/marklogic/gradle/task/CorbTask.groovy
@@ -125,8 +125,7 @@ XQUERY_MODULE"
       //CoRB2 will evaluate System properties for options
       systemProperties(options)
 
-      println "super.exec() ${getSystemProperties()}"
-      //super.exec()
+      super.exec()
     }
 
   /**

--- a/src/main/groovy/com/marklogic/gradle/task/CorbTask.groovy
+++ b/src/main/groovy/com/marklogic/gradle/task/CorbTask.groovy
@@ -27,7 +27,9 @@ class CorbTask extends JavaExec {
   @TaskAction
   @Override
   public void exec() {
-    setClasspath(getProject().configurations.corb)
+    if (getProject().configurations.findByName('corb')) {
+      setClasspath(getProject().configurations.corb)
+    }
     setMain("com.marklogic.developer.corb.Manager")
 
     Map options = buildCorbOptions()

--- a/src/main/groovy/com/marklogic/gradle/task/CorbTask.groovy
+++ b/src/main/groovy/com/marklogic/gradle/task/CorbTask.groovy
@@ -7,6 +7,49 @@ import com.marklogic.appdeployer.AppConfig
 
 class CorbTask extends JavaExec {
 
+  CorbTask() {
+    //Augment with member variables and a mapping of CoRB2 options
+    /*
+    * TODO: replace hard-coded CSV of options with a reference to the CoRB Options class,
+    *       once the next version of CoRB2 is released:
+    *
+      CorbTask.metaClass.corbOptions = com.marklogic.developer.corb.Options.class.declaredFields.findAll { !it.synthetic }.collectEntries {
+    */
+    this.metaClass.corbOptions = "BATCH-SIZE,BATCH-URI-DELIM,COLLECTION-NAME,DECRYPTER,\
+ERROR-FILE-NAME,EXIT-CODE-NO-URIS,EXPORT_FILE_AS_ZIP,\
+EXPORT-FILE-BOTTOM-CONTENT,EXPORT-FILE-DIR,EXPORT-FILE-HEADER-LINE-COUNT,\
+EXPORT-FILE-NAME,EXPORT-FILE-PART-EXT,\
+EXPORT-FILE-SORT,EXPORT-FILE-SORT-COMPARATOR,\
+EXPORT-FILE-TOP-CONTENT,EXPORT-FILE-URI-TO-PATH,\
+FAIL-ON-ERROR,INSTALL,INIT-MODULE,INIT-TASK,JASYPT-PROPERTIES-FILE,\
+MAX_OPTS_FROM_MODULE,MODULES-DATABASE,MODULE-ROOT,OPTIONS-FILE,\
+POST-BATCH-MODULE,POST-BATCH-TASK,POST-BATCH-XQUERY-MODULE,\
+PRE-BATCH-MODULE,PRE-BATCH-TASK,PRE-BATCH-XQUERY-MODULE,\
+PRIVATE-KEY-ALGORITHM,PRIVATE-KEY-FILE,\
+PROCESS-MODULE,PROCESS-TASK,\
+QUERY-RETRY-LIMIT,QUERY-RETRY-INTERVAL,\
+SSL-CIPHER-SUITES,SSL-CONFIG-CLASS,SSL-ENABLED-PROTOCOLS,SSL-KEY-PASSWORD,\
+SSL-KEYSTORE,SSL-KEYSTORE-PASSWORD,SSL-KEYSTORE-TYPE,SSL-PROPERTIES-FILE,\
+THREAD-COUNT,URIS_BATCH_REF,URIS-FILE,URIS-LOADER,URIS-MODULE,URIS-REPLACE-PATTERN,\
+XCC_CONNECTION_RETRY_LIMIT,XCC-CONNECTION-RETRY-INTERVAL,XCC-CONNECTION-URI,\
+XCC-DBNAME,XCC-HOSTNAME,XCC-PASSWORD,XCC-PORT,XCC-USERNAME,\
+XQUERY_MODULE"
+      .tokenize(',').collectEntries {
+        String camel = it.toLowerCase().split('_|-').collect { it.capitalize() }.join('')
+        // create Map entry gradle property and original values, for easy lookup/translation
+        String lowerCamel = new StringBuffer(camel.length())
+                  .append(Character.toLowerCase(camel.charAt(0)))
+                  .append(camel.substring(1))
+                  .toString();
+
+        //add the lowerCamelCased CoRB2 option as a member variable
+        this.metaClass[lowerCamel] = null
+
+        // Create a 'corb' prefixed camelCased entry (i.e. URIS-FILE => corbUrisFile )
+        // mapped to the original CoRB2 option for lookup/conversion
+        [(CORB_PROPERTY_PREFIX + camel): it]
+    }
+  }
   // prefix for corb project properties, to ensure no conflicts with other project properties
   private static final String CORB_PROPERTY_PREFIX = "corb"
 
@@ -128,47 +171,4 @@ class CorbTask extends JavaExec {
       [(corbOptions[it]): project[it]]
     }
   }
-}
-
-//Augment the CorbTask with member variables and a mapping of CoRB2 options
-
-/*
-* TODO: replace hard-coded CSV of options with a reference to the CoRB Options class,
-*       once the next version of CoRB2 is released:
-*
-  CorbTask.metaClass.corbOptions = com.marklogic.developer.corb.Options.class.declaredFields.findAll { !it.synthetic }.collectEntries {
-*/
-CorbTask.metaClass.corbOptions = "BATCH-SIZE,BATCH-URI-DELIM,COLLECTION-NAME,DECRYPTER,\
-ERROR-FILE-NAME,EXIT-CODE-NO-URIS,EXPORT_FILE_AS_ZIP,\
-EXPORT-FILE-BOTTOM-CONTENT,EXPORT-FILE-DIR,EXPORT-FILE-HEADER-LINE-COUNT,\
-EXPORT-FILE-NAME,EXPORT-FILE-PART-EXT,\
-EXPORT-FILE-SORT,EXPORT-FILE-SORT-COMPARATOR,\
-EXPORT-FILE-TOP-CONTENT,EXPORT-FILE-URI-TO-PATH,\
-FAIL-ON-ERROR,INSTALL,INIT-MODULE,INIT-TASK,JASYPT-PROPERTIES-FILE,\
-MAX_OPTS_FROM_MODULE,MODULES-DATABASE,MODULE-ROOT,OPTIONS-FILE,\
-POST-BATCH-MODULE,POST-BATCH-TASK,POST-BATCH-XQUERY-MODULE,\
-PRE-BATCH-MODULE,PRE-BATCH-TASK,PRE-BATCH-XQUERY-MODULE,\
-PRIVATE-KEY-ALGORITHM,PRIVATE-KEY-FILE,\
-PROCESS-MODULE,PROCESS-TASK,\
-QUERY-RETRY-LIMIT,QUERY-RETRY-INTERVAL,\
-SSL-CIPHER-SUITES,SSL-CONFIG-CLASS,SSL-ENABLED-PROTOCOLS,SSL-KEY-PASSWORD,\
-SSL-KEYSTORE,SSL-KEYSTORE-PASSWORD,SSL-KEYSTORE-TYPE,SSL-PROPERTIES-FILE,\
-THREAD-COUNT,URIS_BATCH_REF,URIS-FILE,URIS-LOADER,URIS-MODULE,URIS-REPLACE-PATTERN,\
-XCC_CONNECTION_RETRY_LIMIT,XCC-CONNECTION-RETRY-INTERVAL,XCC-CONNECTION-URI,\
-XCC-DBNAME,XCC-HOSTNAME,XCC-PASSWORD,XCC-PORT,XCC-USERNAME,\
-XQUERY_MODULE"
-.tokenize(',').collectEntries {
-    String camel = it.toLowerCase().split('_|-').collect { it.capitalize() }.join('')
-    // create Map entry gradle property and original values, for easy lookup/translation
-    String lowerCamel = new StringBuffer(camel.length())
-            .append(Character.toLowerCase(camel.charAt(0)))
-            .append(camel.substring(1))
-            .toString();
-
-    //add the lowerCamelCased CoRB2 option as a member variable
-    CorbTask.metaClass[lowerCamel] = null
-
-    //Create a 'corb' prefixed camelCased (i.e. URIS-FILE => corbUrisFile ) entry
-    //mapped to the original CoRB2 option for lookup/conversion
-    [(CorbTask.CORB_PROPERTY_PREFIX + camel): it]
 }

--- a/src/main/groovy/com/marklogic/gradle/task/CorbTask.groovy
+++ b/src/main/groovy/com/marklogic/gradle/task/CorbTask.groovy
@@ -7,64 +7,217 @@ import com.marklogic.appdeployer.AppConfig
 
 class CorbTask extends JavaExec {
 
-    String xccUrl
-    String collectionName = '""'
+  // prefix for corb project properties, to ensure no conflicts with other project properties
+  private static final String CORB_PROPERTY_PREFIX = "corb"
 
+    /*
+    * TODO: replace hard-coded CSV of options with a reference to the CoRB Options class,
+    *       once the next version of CoRB2 is released:
+    *
+      Map corbOptions = com.marklogic.developer.corb.Options.class.declaredFields.findAll { !it.synthetic }.collectEntries {
+        //Create a 'corb' prefixed camelCased value (i.e. URIS-FILE => corbUrisFile )
+        String gradleProperty = 'corb' + it.toLowerCase().split('_|-').collect { it.capitalize() }.join('')
+        // create Map entry
+        [(gradleProperty): it]
+       }
+    */
+    Map corbOptions = "BATCH-SIZE,BATCH-URI-DELIM,COLLECTION-NAME,DECRYPTER,\
+ERROR-FILE-NAME,EXIT-CODE-NO-URIS,EXPORT_FILE_AS_ZIP,\
+EXPORT-FILE-BOTTOM-CONTENT,EXPORT-FILE-DIR,EXPORT-FILE-HEADER-LINE-COUNT,\
+EXPORT-FILE-NAME,EXPORT-FILE-PART-EXT,\
+EXPORT-FILE-SORT,EXPORT-FILE-SORT-COMPARATOR,\
+EXPORT-FILE-TOP-CONTENT,EXPORT-FILE-URI-TO-PATH,\
+FAIL-ON-ERROR,INSTALL,INIT-MODULE,INIT-TASK,JASYPT-PROPERTIES-FILE,\
+MAX_OPTS_FROM_MODULE,MODULES-DATABASE,MODULE-ROOT,OPTIONS-FILE,\
+POST-BATCH-MODULE,POST-BATCH-TASK,POST-BATCH-XQUERY-MODULE,\
+PRE-BATCH-MODULE,PRE-BATCH-TASK,PRE-BATCH-XQUERY-MODULE,\
+PRIVATE-KEY-ALGORITHM,PRIVATE-KEY-FILE,\
+PROCESS-MODULE,PROCESS-TASK,\
+QUERY-RETRY-LIMIT,QUERY-RETRY-INTERVAL,\
+SSL-CIPHER-SUITES,SSL-CONFIG-CLASS,SSL-ENABLED-PROTOCOLS,SSL-KEY-PASSWORD,\
+SSL-KEYSTORE,SSL-KEYSTORE-PASSWORD,SSL-KEYSTORE-TYPE,SSL-PROPERTIES-FILE,\
+THREAD-COUNT,URIS_BATCH_REF,URIS-FILE,URIS-LOADER,URIS-MODULE,URIS-REPLACE-PATTERN,\
+XCC_CONNECTION_RETRY_LIMIT,XCC-CONNECTION-RETRY-INTERVAL,XCC-CONNECTION-URI,\
+XCC-DBNAME,XCC-HOSTNAME,XCC-PASSWORD,XCC-PORT,XCC-USERNAME,\
+XQUERY_MODULE"
+.tokenize(',').collectEntries {
+        //Create a 'corb' prefixed camelCased value (i.e. URIS-FILE => corbUrisFile )
+        String gradleProperty = CORB_PROPERTY_PREFIX + it.toLowerCase().split('_|-').collect { it.capitalize() }.join('')
+        // create Map entry gradle property and original values, for easy lookup/translation
+        [(gradleProperty): it]
+    }
+
+    String xccUrl //same as CoRB option: xccConnectionUri
     // It's common practice for the uris/transform modules to have the same prefix, so just set this if that's the
     // case - e.g. convert-uris.xqy and convert-transform.xqy
     String modulePrefix
+    // Otherwise, set processModule (or transformModule) and either (urisModule or urisFile)
+    String transformModule //same as CoRB option: processModule
 
-    // Otherwise, set transformModule and urisModule
-    String transformModule
-    String urisModule
-    
+
+    //These fields correspond directly to the CoRB2 options in the comments
+    String batchSize // BATCH-SIZE
+    String batchUriDelim // BATCH-URI-DELIM
+    String collectionName // COLLECTION-NAME
+    String decrypter // DECRYPTER
+    String errorFileName //ERROR-FILE-NAME
+    String exitCodeNoUris // EXIT-CODE-NO-URIS
+    def exportFileAsZip // EXPORT_FILE_AS_ZIP
+    String exportFileBottomContent // EXPORT-FILE-BOTTOM-CONTENT
+    String exportFileDir // EXPORT-FILE-DIR
+    String exportFileHeaderLineCount // EXPORT-FILE-HEADER-LINE-COUNT
+    String exportFileName // EXPORT-FILE-NAME
+    String exportFilePartExt // EXPORT-FILE-PART-EXT
+    String exportFileSort // EXPORT-FILE-SORT
+    String exportFileSortComparator // EXPORT-FILE-SORT-COMARATOR
+    String exportFileTopContent // EXPORT-FILE-TOP-CONTENT
+    String exportFileUriToPath // EXPORT-FILE-URI-TO-PATH
+    def failOnError // FAIL-ON-ERROR
+    def install = false // INSTALL
+    String initModule // INIT-MODULE
+    String initTask // INIT-TASK
+    String jasyptPropertiesFile // JASYPT-PROPERTIES-FILE
+    def maxOptsFromModule // MAX_OPTS_FROM_MODULE
+    String modulesDatabase // MODULES-DATABASE
+    String moduleRoot = "/"  // MODULE-ROOT
+    String optionsFile // OPTIONS-FILE
+    String postBatchModule // POST-BATCH-MODULE
+    String postBatchTask // POST-BATCH-TASK
+    String preBatchModule // PRE-BATCH-MODULE
+    String preBatchTask // PRE-BATCH-TASK
+    String privateKeyAlgorithm // PRIVATE-KEY-ALGORITHM
+    String privateKeyFile // PRIVATE-KEY-FILE
+    String processModule // PROCESS-MODULE
+    String processTask // PROCESS-TASK
+    def queryRetryLimit // QUERY-RETRY-LIMIT
+    def queryRetryInterval // QUERY-RETRY-INTERVAL
+    String sslCipherSuites // SSL-CIPHER-SUITES
+    String sslConfigClass // SSL-CONFIG-CLASS
+    String sslEnabledProtocos // SSL-ENABLED-PROTOCOLS
+    String sslKeystore // SSL-KEYSTORE
+    String sslKeyPassword // SSL-KEY-PASSWORD
+    String sslKeystorePassword // SSL-KEYSTORE-PASSWORD
+    String sslKeystoreType // SSL-KEYSTORE-TYPE
+    String sslPropertiesFile // SSL-PROPERTIES-FILE
     // corb defaults to 1, but 8 seems like a more common default
-    int threadCount = 8
-    
-    String moduleRoot = "/"
-    
-    String modulesDatabase
-    
-    String install = "false"
-    
+    def threadCount = 8 // THREAD-COUNT
+    String urisBatchRef // URIS_BATCH_REF
+    String urisFile // URIS-FILE
+    String urisLoader // URIS-LOADER
+    String urisModule // URIS-MODULE
+    String urisReplacePattern // URIS-REPLACE-PATTERN
+    def xccConnectionRetryLimit // XCC-CONNECTION-RETRY-LIMIT
+    def xccConnectionRetryInterval // XCC-CONNECTION-RETRY-INTERVAL
+    String xccConnectionUri // XCC-CONNECTION-URI
+    String xccDbname // XCC-DBNAME
+    String xccHostname // XCC-HOSTNAME
+    String xccPassword // XCC-PASSWORD
+    def xccPort // XCC-PORT
+    String xccUsername // XCC-USERNAME
+
     @TaskAction
     @Override
     public void exec() {
-        setMain("com.marklogic.developer.corb.Manager")
+      setClasspath(getProject().configurations.corb)
+      setMain("com.marklogic.developer.corb.Manager")
 
-        AppConfig config = getProject().property("mlAppConfig")
+      Map options = buildCorbOptions()
+      //CoRB2 will evaluate System properties for options
+      systemProperties(options)
 
-        List<String> newArgs = new ArrayList<>()
-
-        newArgs.add(xccUrl)
-
-        newArgs.add(collectionName)
-
-        if (modulePrefix) {
-            newArgs.add(modulePrefix + "-transform.xqy")
-        } else {
-            newArgs.add(transformModule)
-        }
-        
-        newArgs.add(threadCount + "")
-        
-        if (modulePrefix) {
-            newArgs.add(modulePrefix + "-uris.xqy")
-        } else {
-            newArgs.add(urisModule)
-        }
-        
-        newArgs.add(moduleRoot)
-        
-        if (modulesDatabase) {
-            newArgs.add(modulesDatabase)
-        } else {
-            newArgs.add(config.getModulesDatabaseName())
-        }
-        
-        newArgs.add(install)
-        
-        setArgs(newArgs)
-        super.exec()
+      println "super.exec() ${getSystemProperties()}"
+      //super.exec()
     }
+
+  /**
+  * Construct CoRB2 options from the following sources:
+  * task variables - lowerCamelCase names that correspond to their CoRB2
+  *                  option (i.e. optionsFile => OPTIONS-FILE)
+  * project properties - Project properties with the naming convention
+  *                      of a 'corb' prefix and CamelCased CoRB2 option name
+  *                      (i.e. corbOptionsFile => OPTIONS-FILE)
+  * System properties - Any System property with a CoRB2 option name
+  *
+  * If properties are defined in more than one place, System properties will take
+  * precedence over Project properties, which take precedence over task member variables.
+  *
+  * @return Map of CoRB2 options
+  */
+  public Map buildCorbOptions() {
+    //first, convert legacy task properties and generate options from conventions
+    Map options = collectNormalizedOptions()
+    //collect all of the corb task options (i.e. threadCount=12)
+    options << collectMemberVariables()
+    //apply any corb project properties (i.e. -PcorbThreadCount=12)
+    options << collectCorbProjectProperties()
+    //apply any CoRB2 System properties (i.e. -DTHREAD-COUNT=12)
+    options << collectSystemProperties()
+    options //return the merged options
+  }
+
+  /**
+  * Normalize corb task properties
+  * @return Map of CoRB2 options
+  */
+  public Map collectNormalizedOptions() {
+    Map options = [:]
+
+    if (xccUrl) {
+      options['XCC-CONNECTION-URI'] = xccUrl
+    }
+
+    if (transformModule) {
+      options['PROCESS-MODULE'] = transformModule
+    }
+
+    //if modulePrefix is specified, then generate the selector and transform filenames
+    if (modulePrefix) {
+      options['URIS-MODULE'] = modulePrefix + "-uris.xqy"
+      options['PROCESS-MODULE'] = modulePrefix + "-transform.xqy"
+    }
+
+    String modulesDatabaseName = getProject().property("mlAppConfig").getModulesDatabaseName()
+    if (modulesDatabaseName) {
+      options['MODULES-DATABASE'] = modulesDatabaseName
+    }
+    options //return any options constructed from CorbTask conventions
+  }
+
+  /**
+  * Inspect the Task member variables and convert into CoRB2 options
+  * @return Map of CoRB2 options
+  */
+  public Map collectMemberVariables() {
+    //look for member variables where name match corbOption naming conventions
+    this.class.declaredFields.collectEntries {
+      String name = it.name.replace("_","") //normalize removing leading/trailing "_"
+      String corbOptionKey = CORB_PROPERTY_PREFIX + name.capitalize()
+      //evaluate whether a value is set and the name matches the corbOptions key pattern
+      if (this[it.name] && corbOptions[corbOptionKey]) {
+        [(corbOptions[corbOptionKey]): this[name] ]
+      } else {
+        [:]
+      }
+    }
+  }
+
+  /**
+  * Find all CoRB2 System.properties
+  * @return Map of CoRB2 options
+  */
+  public Map collectSystemProperties() {
+    System.properties.findAll { corbOptions.containsValue(it.key) }
+  }
+
+  /**
+  * For each of project properties specified with the convention corbXxxYyy,
+  * construct a CoRB2 option
+  * @return Map of CoRB2 options
+  */
+  public Map collectCorbProjectProperties() {
+    project.properties.keySet().intersect(corbOptions.keySet()).collectEntries {
+      [(corbOptions[it]): project[it]]
+    }
+  }
+
 }

--- a/src/main/groovy/com/marklogic/gradle/task/CorbTask.groovy
+++ b/src/main/groovy/com/marklogic/gradle/task/CorbTask.groovy
@@ -10,123 +10,32 @@ class CorbTask extends JavaExec {
   // prefix for corb project properties, to ensure no conflicts with other project properties
   private static final String CORB_PROPERTY_PREFIX = "corb"
 
-    /*
-    * TODO: replace hard-coded CSV of options with a reference to the CoRB Options class,
-    *       once the next version of CoRB2 is released:
-    *
-      Map corbOptions = com.marklogic.developer.corb.Options.class.declaredFields.findAll { !it.synthetic }.collectEntries {
-        //Create a 'corb' prefixed camelCased value (i.e. URIS-FILE => corbUrisFile )
-        String gradleProperty = 'corb' + it.toLowerCase().split('_|-').collect { it.capitalize() }.join('')
-        // create Map entry
-        [(gradleProperty): it]
-       }
-    */
-    Map corbOptions = "BATCH-SIZE,BATCH-URI-DELIM,COLLECTION-NAME,DECRYPTER,\
-ERROR-FILE-NAME,EXIT-CODE-NO-URIS,EXPORT_FILE_AS_ZIP,\
-EXPORT-FILE-BOTTOM-CONTENT,EXPORT-FILE-DIR,EXPORT-FILE-HEADER-LINE-COUNT,\
-EXPORT-FILE-NAME,EXPORT-FILE-PART-EXT,\
-EXPORT-FILE-SORT,EXPORT-FILE-SORT-COMPARATOR,\
-EXPORT-FILE-TOP-CONTENT,EXPORT-FILE-URI-TO-PATH,\
-FAIL-ON-ERROR,INSTALL,INIT-MODULE,INIT-TASK,JASYPT-PROPERTIES-FILE,\
-MAX_OPTS_FROM_MODULE,MODULES-DATABASE,MODULE-ROOT,OPTIONS-FILE,\
-POST-BATCH-MODULE,POST-BATCH-TASK,POST-BATCH-XQUERY-MODULE,\
-PRE-BATCH-MODULE,PRE-BATCH-TASK,PRE-BATCH-XQUERY-MODULE,\
-PRIVATE-KEY-ALGORITHM,PRIVATE-KEY-FILE,\
-PROCESS-MODULE,PROCESS-TASK,\
-QUERY-RETRY-LIMIT,QUERY-RETRY-INTERVAL,\
-SSL-CIPHER-SUITES,SSL-CONFIG-CLASS,SSL-ENABLED-PROTOCOLS,SSL-KEY-PASSWORD,\
-SSL-KEYSTORE,SSL-KEYSTORE-PASSWORD,SSL-KEYSTORE-TYPE,SSL-PROPERTIES-FILE,\
-THREAD-COUNT,URIS_BATCH_REF,URIS-FILE,URIS-LOADER,URIS-MODULE,URIS-REPLACE-PATTERN,\
-XCC_CONNECTION_RETRY_LIMIT,XCC-CONNECTION-RETRY-INTERVAL,XCC-CONNECTION-URI,\
-XCC-DBNAME,XCC-HOSTNAME,XCC-PASSWORD,XCC-PORT,XCC-USERNAME,\
-XQUERY_MODULE"
-.tokenize(',').collectEntries {
-        //Create a 'corb' prefixed camelCased value (i.e. URIS-FILE => corbUrisFile )
-        String gradleProperty = CORB_PROPERTY_PREFIX + it.toLowerCase().split('_|-').collect { it.capitalize() }.join('')
-        // create Map entry gradle property and original values, for easy lookup/translation
-        [(gradleProperty): it]
-    }
+  String xccUrl //same as xccConnectionUri
+  // It's common practice for the uris/transform modules to have the same prefix, so just set this if that's the
+  // case - e.g. convert-uris.xqy and convert-transform.xqy
+  String modulePrefix
+  // Otherwise, set processModule (formerly transformModule) and urisModule
+  String transformModule //same as processModule
 
-    String xccUrl //same as CoRB option: xccConnectionUri
-    // It's common practice for the uris/transform modules to have the same prefix, so just set this if that's the
-    // case - e.g. convert-uris.xqy and convert-transform.xqy
-    String modulePrefix
-    // Otherwise, set processModule (or transformModule) and either (urisModule or urisFile)
-    String transformModule //same as CoRB option: processModule
+  def install = false // INSTALL
 
+  String moduleRoot = "/"  // MODULE-ROOT
 
-    //These fields correspond directly to the CoRB2 options in the comments
-    String batchSize // BATCH-SIZE
-    String batchUriDelim // BATCH-URI-DELIM
-    String collectionName // COLLECTION-NAME
-    String decrypter // DECRYPTER
-    String errorFileName //ERROR-FILE-NAME
-    String exitCodeNoUris // EXIT-CODE-NO-URIS
-    def exportFileAsZip // EXPORT_FILE_AS_ZIP
-    String exportFileBottomContent // EXPORT-FILE-BOTTOM-CONTENT
-    String exportFileDir // EXPORT-FILE-DIR
-    String exportFileHeaderLineCount // EXPORT-FILE-HEADER-LINE-COUNT
-    String exportFileName // EXPORT-FILE-NAME
-    String exportFilePartExt // EXPORT-FILE-PART-EXT
-    String exportFileSort // EXPORT-FILE-SORT
-    String exportFileSortComparator // EXPORT-FILE-SORT-COMARATOR
-    String exportFileTopContent // EXPORT-FILE-TOP-CONTENT
-    String exportFileUriToPath // EXPORT-FILE-URI-TO-PATH
-    def failOnError // FAIL-ON-ERROR
-    def install = false // INSTALL
-    String initModule // INIT-MODULE
-    String initTask // INIT-TASK
-    String jasyptPropertiesFile // JASYPT-PROPERTIES-FILE
-    def maxOptsFromModule // MAX_OPTS_FROM_MODULE
-    String modulesDatabase // MODULES-DATABASE
-    String moduleRoot = "/"  // MODULE-ROOT
-    String optionsFile // OPTIONS-FILE
-    String postBatchModule // POST-BATCH-MODULE
-    String postBatchTask // POST-BATCH-TASK
-    String preBatchModule // PRE-BATCH-MODULE
-    String preBatchTask // PRE-BATCH-TASK
-    String privateKeyAlgorithm // PRIVATE-KEY-ALGORITHM
-    String privateKeyFile // PRIVATE-KEY-FILE
-    String processModule // PROCESS-MODULE
-    String processTask // PROCESS-TASK
-    def queryRetryLimit // QUERY-RETRY-LIMIT
-    def queryRetryInterval // QUERY-RETRY-INTERVAL
-    String sslCipherSuites // SSL-CIPHER-SUITES
-    String sslConfigClass // SSL-CONFIG-CLASS
-    String sslEnabledProtocos // SSL-ENABLED-PROTOCOLS
-    String sslKeystore // SSL-KEYSTORE
-    String sslKeyPassword // SSL-KEY-PASSWORD
-    String sslKeystorePassword // SSL-KEYSTORE-PASSWORD
-    String sslKeystoreType // SSL-KEYSTORE-TYPE
-    String sslPropertiesFile // SSL-PROPERTIES-FILE
-    // corb defaults to 1, but 8 seems like a more common default
-    def threadCount = 8 // THREAD-COUNT
-    String urisBatchRef // URIS_BATCH_REF
-    String urisFile // URIS-FILE
-    String urisLoader // URIS-LOADER
-    String urisModule // URIS-MODULE
-    String urisReplacePattern // URIS-REPLACE-PATTERN
-    def xccConnectionRetryLimit // XCC-CONNECTION-RETRY-LIMIT
-    def xccConnectionRetryInterval // XCC-CONNECTION-RETRY-INTERVAL
-    String xccConnectionUri // XCC-CONNECTION-URI
-    String xccDbname // XCC-DBNAME
-    String xccHostname // XCC-HOSTNAME
-    String xccPassword // XCC-PASSWORD
-    def xccPort // XCC-PORT
-    String xccUsername // XCC-USERNAME
+  // corb defaults to 1, but 8 seems like a more common default
+  def threadCount = 8 // THREAD-COUNT
 
-    @TaskAction
-    @Override
-    public void exec() {
-      setClasspath(getProject().configurations.corb)
-      setMain("com.marklogic.developer.corb.Manager")
+  @TaskAction
+  @Override
+  public void exec() {
+    setClasspath(getProject().configurations.corb)
+    setMain("com.marklogic.developer.corb.Manager")
 
-      Map options = buildCorbOptions()
-      //CoRB2 will evaluate System properties for options
-      systemProperties(options)
+    Map options = buildCorbOptions()
+    //CoRB2 will evaluate System properties for options
+    systemProperties(options)
 
-      super.exec()
-    }
+    super.exec()
+  }
 
   /**
   * Construct CoRB2 options from the following sources:
@@ -218,5 +127,47 @@ XQUERY_MODULE"
       [(corbOptions[it]): project[it]]
     }
   }
+}
 
+//Augment the CorbTask with member variables and a mapping of CoRB2 options
+
+/*
+* TODO: replace hard-coded CSV of options with a reference to the CoRB Options class,
+*       once the next version of CoRB2 is released:
+*
+  CorbTask.metaClass.corbOptions = com.marklogic.developer.corb.Options.class.declaredFields.findAll { !it.synthetic }.collectEntries {
+*/
+CorbTask.metaClass.corbOptions = "BATCH-SIZE,BATCH-URI-DELIM,COLLECTION-NAME,DECRYPTER,\
+ERROR-FILE-NAME,EXIT-CODE-NO-URIS,EXPORT_FILE_AS_ZIP,\
+EXPORT-FILE-BOTTOM-CONTENT,EXPORT-FILE-DIR,EXPORT-FILE-HEADER-LINE-COUNT,\
+EXPORT-FILE-NAME,EXPORT-FILE-PART-EXT,\
+EXPORT-FILE-SORT,EXPORT-FILE-SORT-COMPARATOR,\
+EXPORT-FILE-TOP-CONTENT,EXPORT-FILE-URI-TO-PATH,\
+FAIL-ON-ERROR,INSTALL,INIT-MODULE,INIT-TASK,JASYPT-PROPERTIES-FILE,\
+MAX_OPTS_FROM_MODULE,MODULES-DATABASE,MODULE-ROOT,OPTIONS-FILE,\
+POST-BATCH-MODULE,POST-BATCH-TASK,POST-BATCH-XQUERY-MODULE,\
+PRE-BATCH-MODULE,PRE-BATCH-TASK,PRE-BATCH-XQUERY-MODULE,\
+PRIVATE-KEY-ALGORITHM,PRIVATE-KEY-FILE,\
+PROCESS-MODULE,PROCESS-TASK,\
+QUERY-RETRY-LIMIT,QUERY-RETRY-INTERVAL,\
+SSL-CIPHER-SUITES,SSL-CONFIG-CLASS,SSL-ENABLED-PROTOCOLS,SSL-KEY-PASSWORD,\
+SSL-KEYSTORE,SSL-KEYSTORE-PASSWORD,SSL-KEYSTORE-TYPE,SSL-PROPERTIES-FILE,\
+THREAD-COUNT,URIS_BATCH_REF,URIS-FILE,URIS-LOADER,URIS-MODULE,URIS-REPLACE-PATTERN,\
+XCC_CONNECTION_RETRY_LIMIT,XCC-CONNECTION-RETRY-INTERVAL,XCC-CONNECTION-URI,\
+XCC-DBNAME,XCC-HOSTNAME,XCC-PASSWORD,XCC-PORT,XCC-USERNAME,\
+XQUERY_MODULE"
+.tokenize(',').collectEntries {
+    String camel = it.toLowerCase().split('_|-').collect { it.capitalize() }.join('')
+    // create Map entry gradle property and original values, for easy lookup/translation
+    String lowerCamel = new StringBuffer(camel.length())
+            .append(Character.toLowerCase(camel.charAt(0)))
+            .append(camel.substring(1))
+            .toString();
+
+    //add the lowerCamelCased CoRB2 option as a member variable
+    CorbTask.metaClass[lowerCamel] = null
+
+    //Create a 'corb' prefixed camelCased (i.e. URIS-FILE => corbUrisFile ) entry
+    //mapped to the original CoRB2 option for lookup/conversion
+    [(CorbTask.CORB_PROPERTY_PREFIX + camel): it]
 }

--- a/src/main/groovy/com/marklogic/gradle/task/CorbTask.groovy
+++ b/src/main/groovy/com/marklogic/gradle/task/CorbTask.groovy
@@ -97,12 +97,11 @@ class CorbTask extends JavaExec {
   */
   public Map collectMemberVariables() {
     //look for member variables where name match corbOption naming conventions
-    this.class.declaredFields.collectEntries {
-      String name = it.name.replace("_","") //normalize removing leading/trailing "_"
-      String corbOptionKey = CORB_PROPERTY_PREFIX + name.capitalize()
+    this.metaClass.getProperties().collectEntries {
+      String corbOptionKey = CORB_PROPERTY_PREFIX + it.name.capitalize()
       //evaluate whether a value is set and the name matches the corbOptions key pattern
       if (this[it.name] && corbOptions[corbOptionKey]) {
-        [(corbOptions[corbOptionKey]): this[name] ]
+        [(corbOptions[corbOptionKey]): this[it.name] ]
       } else {
         [:]
       }


### PR DESCRIPTION
Added explicit fields for each of the CoRB2 options, the ability to set
project properties (with naming convention to prevent conflicts),
and/or System properties. CoRB options are now set using System
properties, allowing for any/all of the options to be specified when
executing the CorbTask.

Project properties use the naming convention of a “corb” prefix and
CamelCased name of the option (i.e. -PcorbThreadCount would set
THREAD-COUNT).

System properties will look for CoRB options with their original names
(i.e. -DTHREAD-COUNT).

Previous CorbTask member variables and behavior were preserved, such as
the convention of constructing the URIS-MODULE and PROCESS-MODULE if
modulePrefix value is specified.

Methods to collect and overlay the CoRB options are extracted into
methods that can be overridden if the user would like to change the
precedence or behavior.