### PR TITLE
Update CorbTask to 2.3.0 and ability to dynamically enhance CorbTask with CoRB Options

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -2,6 +2,7 @@
 /.classpath
 /build
 /.gradle
+/.nb-gradle
 /.settings
 /.project
 ml-gradle-all/build/

--- a/build.gradle
+++ b/build.gradle
@@ -14,7 +14,7 @@ plugins {
   id "maven-publish"
   id "eclipse"
   id "idea"
-  id "com.jfrog.bintray" version "1.5"
+  id "com.jfrog.bintray" version "1.6"
 }
 
 apply plugin: "com.gradle.plugin-publish"

--- a/examples/corb2-project/build.gradle
+++ b/examples/corb2-project/build.gradle
@@ -3,11 +3,28 @@
  * "corb". This configuration is then used as the classpath for CorbTask, which is an extension of Gradle's
  * JavaExec task that exposes the corb options as task attributes. The CorbTask will apply any corb options set via
  * task attributes, project properties, or System properties.
- *
+ */
+
+/*
+ * optionally, set buildscript dependency for CoRB, in order for the CorbTask 
+ * to be enhanced with all of the current CoRB Options. If omitted, a default 
+ * (possibly outdated) set of CoRB options will be applied to the CorbTask.
+ */
+buildscript {
+  repositories {   
+    jcenter()
+    // Needed for corb dependency: XCC
+    maven { url "http://developer.marklogic.com/maven2/" }
+  } 
+  dependencies {
+    //Needed for CorbTask to dynamicaly generate properties from CORB Options class
+    classpath 'com.marklogic:marklogic-corb:2.3.0'
+  }
+}
+
 plugins {
     id "com.marklogic.ml-gradle" version "2.1.0"
 }
-apply plugin: "com.marklogic.ml-gradle"
 
 repositories {
     jcenter()

--- a/examples/corb2-project/build.gradle
+++ b/examples/corb2-project/build.gradle
@@ -1,21 +1,19 @@
 /*
- * This buildscript shows how corb dependencies can be easily declared and then uses in a Gradle configuration named
+ * This buildscript shows how corb dependencies can be easily declared and then a Gradle configuration named
  * "corb". This configuration is then used as the classpath for CorbTask, which is an extension of Gradle's
  * JavaExec task that exposes the corb options as task attributes. The CorbTask will apply any corb options set via
  * task attributes, project properties, or System properties.
- */
+ *
 plugins {
     id "com.marklogic.ml-gradle" version "2.1.0"
 }
+apply plugin: "com.marklogic.ml-gradle"
 
 repositories {
     jcenter()
-
-    // Needed for corb dependencies: XCC, Jasypt(optional)
+    
+    // Needed for corb dependency: XCC
     maven { url "http://developer.marklogic.com/maven2/" }
-
-    // Needed to resolve CoRB2
-    maven { url "http://rjrudin.github.io/marklogic-java/releases" }
 }
 
 configurations {
@@ -27,8 +25,7 @@ configurations {
 
 dependencies {
     // required to run CoRB2
-    corb 'com.marklogic:marklogic-corb:2.2.1'
-
+    corb 'com.marklogic:marklogic-corb:2.3.0'
     // optional
     //corb 'org.jasypt:jasypt:1.9.2' // would be necessary to leverage JasyptDecrypter
 }

--- a/examples/mlcp-project/build.gradle
+++ b/examples/mlcp-project/build.gradle
@@ -1,7 +1,7 @@
 /*
  * This buildscript shows how mlcp dependencies can be easily declared and then uses in a Gradle configuration named
  * "mlcp". This configuration is then used as the classpath for MlcpTask, which is a simple extension of Gradle's
- * JavaExec task that exposes a number of mlcp arguments as task attributes. 
+ * JavaExec task that exposes a number of mlcp arguments as task attributes.
  */
 
 plugins {
@@ -48,11 +48,11 @@ task importSampleData(type: com.marklogic.gradle.task.MlcpTask) {
 
 
 /*
- * Example of using MlcpTask to export data with mlcp. This example also shows how the connection values can be 
- * overridden. 
+ * Example of using MlcpTask to export data with mlcp. This example also shows how the connection values can be
+ * overridden.
  */
 task exportSampleData(type: com.marklogic.gradle.task.MlcpTask) {
-    description = "Example of using mlcp and MlcpTask to export documents; note the args array is used for any args MlcpTask doesn't yet have as task attrsibutes"
+    description = "Example of using mlcp and MlcpTask to export documents; note the args array is used for any args MlcpTask doesn't yet have as task attributes"
     classpath = configurations.mlcp
     command = "EXPORT"
     host = "localhost" // defaults to mlHost
@@ -63,4 +63,3 @@ task exportSampleData(type: com.marklogic.gradle.task.MlcpTask) {
     output_file_path = "data/export"
     args = ["-collection_filter", "sample-import"]
 }
-

--- a/examples/sample-project/build.gradle
+++ b/examples/sample-project/build.gradle
@@ -63,9 +63,6 @@ plugins {
  */
 repositories {
     jcenter()
-
-    // corb2 jar is stored here, waiting for bintray to mirror it
-    maven {url "https://dl.bintray.com/rjrudin/maven/"}
 }
 
 
@@ -87,7 +84,7 @@ dependencies {
     testCompile "com.jayway.restassured:rest-assured:2.4.1"
     
     // corb jar available from jcenter
-    corb "com.marklogic:marklogic-corb:2.2.1"
+    corb "com.marklogic:marklogic-corb:2.3.0"
 }
 
 

--- a/src/main/groovy/com/marklogic/gradle/task/CorbTask.groovy
+++ b/src/main/groovy/com/marklogic/gradle/task/CorbTask.groovy
@@ -7,28 +7,52 @@ import com.marklogic.appdeployer.AppConfig
 
 class CorbTask extends JavaExec {
 
+  //default CORB option list
+  private static String[] DEFAULT_CORB_OPTIONS = "BATCH-SIZE,BATCH-URI-DELIM,COLLECTION-NAME,DECRYPTER,\
+ERROR-FILE-NAME,EXIT-CODE-NO-URIS,EXPORT_FILE_AS_ZIP,\
+EXPORT-FILE-BOTTOM-CONTENT,EXPORT-FILE-DIR,EXPORT-FILE-HEADER-LINE-COUNT,\
+EXPORT-FILE-NAME,EXPORT-FILE-PART-EXT,\
+EXPORT-FILE-SORT,EXPORT-FILE-SORT-COMPARATOR,\
+EXPORT-FILE-TOP-CONTENT,EXPORT-FILE-URI-TO-PATH,\
+FAIL-ON-ERROR,INSTALL,INIT-MODULE,INIT-TASK,JASYPT-PROPERTIES-FILE,\
+MAX_OPTS_FROM_MODULE,MODULES-DATABASE,MODULE-ROOT,OPTIONS-FILE,\
+POST-BATCH-MODULE,POST-BATCH-TASK,POST-BATCH-XQUERY-MODULE,\
+PRE-BATCH-MODULE,PRE-BATCH-TASK,PRE-BATCH-XQUERY-MODULE,\
+PRIVATE-KEY-ALGORITHM,PRIVATE-KEY-FILE,\
+PROCESS-MODULE,PROCESS-TASK,\
+QUERY-RETRY-LIMIT,QUERY-RETRY-INTERVAL,\
+SSL-CIPHER-SUITES,SSL-CONFIG-CLASS,SSL-ENABLED-PROTOCOLS,SSL-KEY-PASSWORD,\
+SSL-KEYSTORE,SSL-KEYSTORE-PASSWORD,SSL-KEYSTORE-TYPE,SSL-PROPERTIES-FILE,\
+THREAD-COUNT,URIS_BATCH_REF,URIS-FILE,URIS-LOADER,URIS-MODULE,URIS-REPLACE-PATTERN,\
+XCC_CONNECTION_RETRY_LIMIT,XCC-CONNECTION-RETRY-INTERVAL,XCC-CONNECTION-URI,\
+XCC-DBNAME,XCC-HOSTNAME,XCC-PASSWORD,XCC-PORT,XCC-USERNAME,\
+XQUERY-MODULE".tokenize(',')
+
   CorbTask() {
-      System.out.println("initializing CorbTask " )
-    //Augment with member variables and a mapping of CoRB2 Options
-    CorbTask.metaClass.corbOptions = Class.forName("com.marklogic.developer.corb.Options", true, Thread.currentThread().contextClassLoader)
+    String[] optionNames = DEFAULT_CORB_OPTIONS  
+    try {
+        optionNames = Class.forName("com.marklogic.developer.corb.Options", true, Thread.currentThread().contextClassLoader)
         .declaredFields
-        .findAll { !it.synthetic }
-        .collectEntries {
-            String option = it.name
-            String camelOption = option.toLowerCase().split('_|-').collect { it.capitalize() }.join('')
-            // create Map entry gradle property and original values, for easy lookup/translation
-            String lowerCamelOption = new StringBuffer(camelOption.length())
-                                        .append(Character.toLowerCase(camelOption.charAt(0)))
-                                        .append(camelOption.substring(1))
-                                        .toString();
+        .findAll { !it.synthetic }.collect { it.get(null) }
+    } catch (ClassNotFoundException ex) {}
+    
+    //Augment with member variables and a mapping of CoRB2 Options    
+    CorbTask.metaClass.corbOptions = optionNames.collectEntries { option ->
+        
+        String camelOption = option.toLowerCase().split('_|-').collect { it.capitalize() }.join('')
+        // create Map entry gradle property and original values, for easy lookup/translation
+        String lowerCamelOption = new StringBuffer(camelOption.length())
+                                    .append(Character.toLowerCase(camelOption.charAt(0)))
+                                    .append(camelOption.substring(1))
+                                    .toString();
 
-            //add the lowerCamelCased CoRB2 option as a member variable
-            this.metaClass[lowerCamelOption] = null
+        //add the lowerCamelCased CoRB2 option as a member variable
+        this.metaClass[lowerCamelOption] = null
 
-            // Create a 'corb' prefixed CamelCased entry (i.e. URIS-FILE => corbUrisFile )
-            // mapped to the original CoRB2 option for lookup/conversion
-            [(CORB_PROPERTY_PREFIX + camelOption): option]
-        }
+        // Create a 'corb' prefixed CamelCased entry (i.e. URIS-FILE => corbUrisFile )
+        // mapped to the original CoRB2 option for lookup/conversion
+        [(CORB_PROPERTY_PREFIX + camelOption): option]
+    }
   }
   // prefix for corb project properties, to ensure no conflicts with other project properties
   private static final String CORB_PROPERTY_PREFIX = "corb"

--- a/src/main/groovy/com/marklogic/gradle/task/CorbTask.groovy
+++ b/src/main/groovy/com/marklogic/gradle/task/CorbTask.groovy
@@ -8,47 +8,27 @@ import com.marklogic.appdeployer.AppConfig
 class CorbTask extends JavaExec {
 
   CorbTask() {
-    //Augment with member variables and a mapping of CoRB2 options
-    /*
-    * TODO: replace hard-coded CSV of options with a reference to the CoRB Options class,
-    *       once the next version of CoRB2 is released:
-    *
-      CorbTask.metaClass.corbOptions = com.marklogic.developer.corb.Options.class.declaredFields.findAll { !it.synthetic }.collectEntries {
-    */
-    this.metaClass.corbOptions = "BATCH-SIZE,BATCH-URI-DELIM,COLLECTION-NAME,DECRYPTER,\
-ERROR-FILE-NAME,EXIT-CODE-NO-URIS,EXPORT_FILE_AS_ZIP,\
-EXPORT-FILE-BOTTOM-CONTENT,EXPORT-FILE-DIR,EXPORT-FILE-HEADER-LINE-COUNT,\
-EXPORT-FILE-NAME,EXPORT-FILE-PART-EXT,\
-EXPORT-FILE-SORT,EXPORT-FILE-SORT-COMPARATOR,\
-EXPORT-FILE-TOP-CONTENT,EXPORT-FILE-URI-TO-PATH,\
-FAIL-ON-ERROR,INSTALL,INIT-MODULE,INIT-TASK,JASYPT-PROPERTIES-FILE,\
-MAX_OPTS_FROM_MODULE,MODULES-DATABASE,MODULE-ROOT,OPTIONS-FILE,\
-POST-BATCH-MODULE,POST-BATCH-TASK,POST-BATCH-XQUERY-MODULE,\
-PRE-BATCH-MODULE,PRE-BATCH-TASK,PRE-BATCH-XQUERY-MODULE,\
-PRIVATE-KEY-ALGORITHM,PRIVATE-KEY-FILE,\
-PROCESS-MODULE,PROCESS-TASK,\
-QUERY-RETRY-LIMIT,QUERY-RETRY-INTERVAL,\
-SSL-CIPHER-SUITES,SSL-CONFIG-CLASS,SSL-ENABLED-PROTOCOLS,SSL-KEY-PASSWORD,\
-SSL-KEYSTORE,SSL-KEYSTORE-PASSWORD,SSL-KEYSTORE-TYPE,SSL-PROPERTIES-FILE,\
-THREAD-COUNT,URIS_BATCH_REF,URIS-FILE,URIS-LOADER,URIS-MODULE,URIS-REPLACE-PATTERN,\
-XCC_CONNECTION_RETRY_LIMIT,XCC-CONNECTION-RETRY-INTERVAL,XCC-CONNECTION-URI,\
-XCC-DBNAME,XCC-HOSTNAME,XCC-PASSWORD,XCC-PORT,XCC-USERNAME,\
-XQUERY_MODULE"
-      .tokenize(',').collectEntries {
-        String camel = it.toLowerCase().split('_|-').collect { it.capitalize() }.join('')
-        // create Map entry gradle property and original values, for easy lookup/translation
-        String lowerCamel = new StringBuffer(camel.length())
-                  .append(Character.toLowerCase(camel.charAt(0)))
-                  .append(camel.substring(1))
-                  .toString();
+      System.out.println("initializing CorbTask " )
+    //Augment with member variables and a mapping of CoRB2 Options
+    CorbTask.metaClass.corbOptions = Class.forName("com.marklogic.developer.corb.Options", true, Thread.currentThread().contextClassLoader)
+        .declaredFields
+        .findAll { !it.synthetic }
+        .collectEntries {
+            String option = it.name
+            String camelOption = option.toLowerCase().split('_|-').collect { it.capitalize() }.join('')
+            // create Map entry gradle property and original values, for easy lookup/translation
+            String lowerCamelOption = new StringBuffer(camelOption.length())
+                                        .append(Character.toLowerCase(camelOption.charAt(0)))
+                                        .append(camelOption.substring(1))
+                                        .toString();
 
-        //add the lowerCamelCased CoRB2 option as a member variable
-        this.metaClass[lowerCamel] = null
+            //add the lowerCamelCased CoRB2 option as a member variable
+            this.metaClass[lowerCamelOption] = null
 
-        // Create a 'corb' prefixed camelCased entry (i.e. URIS-FILE => corbUrisFile )
-        // mapped to the original CoRB2 option for lookup/conversion
-        [(CORB_PROPERTY_PREFIX + camel): it]
-    }
+            // Create a 'corb' prefixed CamelCased entry (i.e. URIS-FILE => corbUrisFile )
+            // mapped to the original CoRB2 option for lookup/conversion
+            [(CORB_PROPERTY_PREFIX + camelOption): option]
+        }
   }
   // prefix for corb project properties, to ensure no conflicts with other project properties
   private static final String CORB_PROPERTY_PREFIX = "corb"
@@ -70,6 +50,7 @@ XQUERY_MODULE"
   @TaskAction
   @Override
   public void exec() {
+    //By convention, if there is a corb configuration, use it to set the classpath  
     if (getProject().configurations.findByName('corb')) {
       setClasspath(getProject().configurations.corb)
     }
@@ -171,4 +152,5 @@ XQUERY_MODULE"
       [(corbOptions[it]): project[it]]
     }
   }
+  
 }


### PR DESCRIPTION
- Updated CoRB references to 2.3.0
- Changed the CorbTask to attempt to obtain the list of CoRB options from the Options class. If not available, uses default list of options.
- Bumped the bintray plugin version to 1.6