### PR TITLE
update mlcp dependency to use https over http

### DIFF
--- a/examples/mlcp-project/build.gradle
+++ b/examples/mlcp-project/build.gradle
@@ -12,7 +12,7 @@ repositories {
 	jcenter()
 
 	// Needed for mlcp dependencies
-	maven { url "http://developer.marklogic.com/maven2/" }
+	maven { url "https://developer.marklogic.com/maven2/" }
 
 	// Needed for hadoop dependencies for mlcp
 	maven { url "http://repository.cloudera.com/artifactory/cloudera-repos/" }


### PR DESCRIPTION
Marklogic seems to have updated their repo to use https. The server was returning a `401: Authorization Required` error when the mlcp dependency was attempting to be accessed via http thus causing the build to fail.